### PR TITLE
claude: Add /rca skill and tighten validation discipline

### DIFF
--- a/.claude/skills/rca/SKILL.md
+++ b/.claude/skills/rca/SKILL.md
@@ -64,24 +64,33 @@ If the bug pre-dates any plausible change, the cause is likely a latent conditio
 
 ### 3. Run the 5-whys chain
 
-Start from the symptom. At each step, the answer becomes the next "why."
+Start from the symptom. At each step, the answer becomes the next "why." Record the chain as a **numbered list**, with each item carrying the same three fields — narrative prose makes it easy to chain unverified claims fluently; explicit per-item fields force evidence per link.
 
-> *Why* did the request return 500?
-> Because the `customers` query returned 0 rows for an authenticated user.
-> *Why* did it return 0 rows?
-> Because the WHERE clause filters on `org_id`, and the user's `org_id` was null.
-> *Why* was `org_id` null?
-> Because the signup flow doesn't backfill `org_id` for users created via the magic-link path.
-> *Why* doesn't it backfill?
-> Because the org-assignment hook is wired to the password-signup path only.
-> *Why* is it wired only there?
-> Because magic-link signup was added later and the author didn't know the hook existed — there was no contract documenting it.
+1. **Why did the request return 500?**
+   - **Answer:** The `customers` query returned 0 rows for an authenticated user.
+   - **Evidence:** `api/customers.ts:42` — `if (rows.length === 0) throw 500`; log `req-id=abc123` shows empty result set.
+
+2. **Why did it return 0 rows?**
+   - **Answer:** The WHERE clause filters on `org_id`, and the user's `org_id` was `null`.
+   - **Evidence:** `api/customers.ts:38` query; `psql> SELECT org_id FROM users WHERE id='…'` → `null`.
+
+3. **Why was `org_id` null?**
+   - **Answer:** The signup flow doesn't backfill `org_id` for users created via the magic-link path.
+   - **Evidence:** `auth/magic-link.ts:71-95` — no call to `assignOrg()`; cf. `auth/password.ts:60` which does call it.
+
+4. **Why doesn't it backfill?**
+   - **Answer:** The org-assignment hook is wired to the password-signup path only.
+   - **Evidence:** `auth/hooks.ts:12` registers only `on('password-signup', …)`.
+
+5. **Why is it wired only there?**
+   - **Answer:** Magic-link signup was added later (commit `a1b2c3d`) and the author didn't know the hook existed — no contract documented it.
+   - **Evidence:** `git log -S "magic-link" auth/`; `docs/auth.md` has no mention of the hook contract.
 
 Rules:
 
 - **Each why is mechanical, not narrative.** Don't jump three layers. One step at a time.
 - **Stop when the answer is "and a fix here prevents siblings."** Above that level you're fixing symptoms; below that level you're philosophising ("because software is hard").
-- **Verify each link.** A 5-whys chain that's never tested against code is fan-fiction. Confirm each step against the actual implementation, log, or query.
+- **Evidence is mandatory, per link.** Each row's Evidence cell must cite a `file:line`, query result, log excerpt, or commit SHA. A blank or hand-wavy cell ("looks like…", "probably because…", "the author must have…") is *itself a finding* — mark the row `UNVERIFIED`, and either go get the evidence or stop the chain there. An unverified link cannot support the links below it.
 - **Branch if needed.** Some failures have multiple parallel causes; run a chain per branch.
 
 ### 4. Distinguish symptom / proximate cause / root cause
@@ -95,6 +104,14 @@ Restate the chain, labelling:
 A fix at the proximate cause stops *this* failure. A fix at the root cause stops the *class*.
 
 Both are legitimate — but the user should choose with eyes open. Present both options.
+
+**Then falsify the root cause.** Per-link evidence proves each step; it does *not* prove the synthesis ("therefore X is the root cause"). A chain can be link-by-link verified and still synthesise to the wrong root — e.g. you found a real defect, but not the one that produced this symptom. Write down:
+
+- **What would we see** (in logs, repro, data) if X were *not* the actual root cause?
+- **Is there a second mechanism** that could produce the same symptom without going through X? If yes, what distinguishes which one fired here?
+- **Cheapest disconfirming experiment** available?
+
+If a cheap disconfirming experiment exists, run it. If not, surface the falsifier as a known limitation — "we believe X is the root cause; we have not ruled out Y." A hypothesis you can't even imagine disproving is religion, not analysis.
 
 ### 5. Sibling-impact sweep
 
@@ -112,6 +129,32 @@ git log -S"<distinctive token>"
 
 Found siblings get reported alongside the primary. A "root cause" with zero siblings is suspicious — re-examine whether you stopped at a proximate cause.
 
+### 5.5. List and validate load-bearing assumptions
+
+Before proposing any fix, write down the assumptions the root-cause hypothesis and the eventual fix rest on, as a **numbered list** with the same three fields per item. Validating-as-you-go produces a list of "things that happen to be true" — listing first, then validating, surfaces the assumptions you actually depend on.
+
+1. **Assumption:** `assignOrg()` is the *only* mechanism that sets `org_id`.
+   - **How validated:** `grep -rn "org_id\s*=" .` — only `assignOrg()` and the seed script write it.
+   - **Result:** Confirmed.
+
+2. **Assumption:** All magic-link users have `org_id = null` (not just the reported one).
+   - **How validated:** `psql> SELECT count(*) FROM users WHERE signup_method='magic_link' AND org_id IS NULL` → 1,247.
+   - **Result:** Confirmed; sibling impact is large.
+
+3. **Assumption:** Adding `assignOrg()` to the magic-link path won't double-assign for users who already have an org.
+   - **How validated:** Read `assignOrg()`: idempotent — early-returns when `org_id` is already set.
+   - **Result:** Confirmed.
+
+4. **Assumption:** The hook contract is the right enforcement layer (vs. a DB constraint).
+   - **How validated:** —
+   - **Result:** UNVERIFIED — surface as open question.
+
+Rules:
+
+- **List the assumption *before* you validate it.** Otherwise you list what you happened to check, not what you actually depend on.
+- **An unvalidated assumption is a load-bearing guess.** If you can't validate one cheaply, that *is* the finding — surface it as an open question rather than quietly proceeding.
+- **The fix may only depend on validated assumptions.** If the proposed fix needs an `UNVERIFIED` assumption to be true, it's a hypothesis dressed as a fix — say so explicitly when proposing it.
+
 ### 6. Propose the fix(es)
 
 Two distinct proposals, separated:
@@ -122,6 +165,22 @@ Two distinct proposals, separated:
 For each: files, approach, test coverage, blast radius, rollback story.
 
 Recommend one. The recommendation depends on urgency, risk, and whether the symptom fix would mask the cause from future detection.
+
+### 6.5. Counterfactual: would the fix have prevented the captured repro?
+
+Close the loop between cause and fix. For each proposed fix (especially the root-cause one — the symptom fix is trivially counterfactual-true by construction), walk it through the captured failure and answer:
+
+- **If this fix had been in place when the failure was captured, would the repro still fire?**
+- **Which link in the 5-whys chain does the fix break?** If the answer is "link 2" but you claimed the root cause is at link 5, the fix is too shallow — name what it doesn't prevent.
+- **Does the fix address the captured failure**, or only a related failure that shares the same root cause?
+
+Land on one of:
+
+- **Confirmed** — repro would not fire under the fix; name the link it breaks.
+- **Confirmed for this case, but a sibling path remains** — fix stops the captured repro but not all manifestations from the same root. List the survivors (and consider whether the fix is wide enough).
+- **Unconfirmed** — the fix addresses a real defect but it's not clear it addresses *this* failure. **Stop.** Either the chain points at the wrong cause or the fix targets the wrong layer; revisit before recommending.
+
+A fix that can't survive its own counterfactual is a hypothesis dressed as a fix. Say so when proposing it, or pick a different fix.
 
 ### 7. Prevent the class
 
@@ -179,10 +238,12 @@ The RCA is complete when **all** of these are true. Each item is answerable with
 - [ ] Failure captured: symptom, scope, expected vs. actual, time window — all written down.
 - [ ] Repro or trace established; if neither, the *finding* is "we need instrumentation" and the RCA is paused, not faked.
 - [ ] Timeline reconstructed: the change(s) plausibly responsible are named, with commits / deploys / config flips cited.
-- [ ] 5-whys chain written out, each link verified against actual code / logs / data (not memory).
-- [ ] Symptom / proximate cause / root cause explicitly labelled and distinguished.
-- [ ] Sibling sweep performed; either siblings are listed, or the absence is justified.
+- [ ] 5-whys chain produced as a numbered list; **every item has a populated Answer and Evidence field** (file:line, query result, log excerpt, or commit SHA). Any `UNVERIFIED` link is explicitly flagged, and no link below an `UNVERIFIED` one is treated as proven.
+- [ ] Symptom / proximate cause / root cause explicitly labelled and distinguished — **and** the root cause is falsified: what observation would disprove it is written down, or the absence of a cheap falsifier is itself surfaced as a limitation.
+- [ ] Sibling sweep performed; either siblings are listed, or the absence is justified — "no siblings" alone is not enough.
+- [ ] Load-bearing assumptions enumerated as a numbered list with populated **How validated** and **Result** for each. Any `UNVERIFIED` assumption is surfaced as an open question; the recommended fix does **not** silently depend on one.
 - [ ] Two fix proposals presented (symptom-level and root-cause-level), with a recommendation and a reason.
+- [ ] Counterfactual check performed on the recommended fix; result is recorded as **Confirmed**, **Confirmed-with-survivors** (survivors listed), or **Unconfirmed** — and **Unconfirmed means the RCA is not done**.
 - [ ] Prevention proposed: at minimum a test; ideally a guardrail or doc that prevents the *class*.
 - [ ] Report delivered inverted-pyramid, with open questions surfaced (not silently answered).
 - [ ] No "human error" conclusions. No findings that name a person rather than a system.

--- a/.claude/skills/rca/SKILL.md
+++ b/.claude/skills/rca/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: rca
+description: Conduct a root-cause analysis on a bug, incident, or regression — reproduce the failure, reconstruct the timeline, run a 5-whys chain, distinguish symptom from proximate cause from root cause, sweep for siblings, and propose a fix that addresses the cause (not the symptom). Use when the user says "/rca", "root cause", "5 whys", "why is this failing", "investigate this regression", or after any failure the team wants to learn from rather than just patch.
+---
+
+# RCA: failure-first investigation
+
+The point of this skill is **not** to fix a bug. It is to understand *why* the bug happened deeply enough that the fix kills the cause, not just the symptom — and to catch the class of failure next time, not just this instance.
+
+`/super-plan` plans a *change* you want to make. `/rca` investigates a *failure* you didn't want. The shapes are different: planning starts from a goal, RCA starts from a fact (something broke).
+
+## When to invoke
+
+- "/rca <thing>" / "do a root cause analysis on …"
+- Regressions: something that used to work no longer does
+- Production incidents and post-mortems
+- Bugs whose first-pass fix the user finds suspicious ("are we sure that's *why* it broke?")
+- Any failure where the team will pay for the same bug again if you just patch the symptom
+- When `/super-plan`'s validation reveals that the load-bearing assumption *was already wrong in prod*
+
+Do **not** invoke for: trivial bugs with obvious causes (typo, missing null check on a fresh edit, lint error), or for *future* failures you're trying to design around — that's `/super-plan` territory.
+
+## Operating principles
+
+- **Repro first.** A bug you can't trigger is a story, not a finding. Until you can reproduce it (or read a trace of it firing), every theory is unfalsifiable.
+- **The symptom is not the cause.** It's evidence of the cause. Treating it as the cause produces fixes that hold until the next adjacent failure.
+- **Ask why five times, mechanically.** Each answer becomes the next question's subject. Stop when you hit something whose fix prevents siblings, not just this instance.
+- **Look for siblings.** A real root cause almost always has more than one manifestation. If you found only one, you probably stopped at a proximate cause.
+- **Fix the cause, prevent the class.** "What stops this bug" and "what stops bugs *like* this" are different questions. RCA owes the user both.
+
+## Workflow
+
+### 1. Capture the failure
+
+Before any theorising, write down:
+
+- **Symptom** — what the user/system observed (error message, wrong output, hang, crash). Quote logs/screenshots verbatim if available.
+- **Scope** — who is affected (one user / all users / specific tenant / specific environment), since when, how often.
+- **Expected vs. actual** — what the system was supposed to do.
+- **Reproduction** — exact steps. If unknown, treat finding a repro as step 1.5.
+
+If any of this is ambiguous, **ask the user**. RCA on a fuzzy symptom is a fishing expedition.
+
+### 1.5. Establish a repro (or a trace)
+
+You need one of:
+
+- A deterministic reproduction (manual steps, failing test, script)
+- A captured trace of the failure (logs, stack trace, error report with enough context)
+
+Without either, every subsequent step is speculation. If a repro is elusive, that itself is the finding — surface it and discuss instrumentation before continuing.
+
+### 2. Reconstruct the timeline
+
+When did it start? What changed?
+
+```bash
+git log --since="<earliest known-good>" --until="<earliest known-bad>" -- <area>
+```
+
+Also check: deploys, dependency bumps, infra changes, feature-flag toggles, data migrations, traffic shifts. The cause is almost always in the delta.
+
+If the bug pre-dates any plausible change, the cause is likely a latent condition that something *new* started exercising. Look for what's new in the inputs, not the code.
+
+### 3. Run the 5-whys chain
+
+Start from the symptom. At each step, the answer becomes the next "why."
+
+> *Why* did the request return 500?
+> Because the `customers` query returned 0 rows for an authenticated user.
+> *Why* did it return 0 rows?
+> Because the WHERE clause filters on `org_id`, and the user's `org_id` was null.
+> *Why* was `org_id` null?
+> Because the signup flow doesn't backfill `org_id` for users created via the magic-link path.
+> *Why* doesn't it backfill?
+> Because the org-assignment hook is wired to the password-signup path only.
+> *Why* is it wired only there?
+> Because magic-link signup was added later and the author didn't know the hook existed — there was no contract documenting it.
+
+Rules:
+
+- **Each why is mechanical, not narrative.** Don't jump three layers. One step at a time.
+- **Stop when the answer is "and a fix here prevents siblings."** Above that level you're fixing symptoms; below that level you're philosophising ("because software is hard").
+- **Verify each link.** A 5-whys chain that's never tested against code is fan-fiction. Confirm each step against the actual implementation, log, or query.
+- **Branch if needed.** Some failures have multiple parallel causes; run a chain per branch.
+
+### 4. Distinguish symptom / proximate cause / root cause
+
+Restate the chain, labelling:
+
+- **Symptom** — what the user saw
+- **Proximate cause** — the line of code or condition that directly produced the symptom
+- **Root cause** — the upstream defect, missing safeguard, or design gap that *allowed* the proximate cause to exist
+
+A fix at the proximate cause stops *this* failure. A fix at the root cause stops the *class*.
+
+Both are legitimate — but the user should choose with eyes open. Present both options.
+
+### 5. Sibling-impact sweep
+
+If the root cause is real, where else does it manifest?
+
+- Other call sites of the same function / hook / path
+- Other entry points that bypass the same safeguard
+- Other tenants / environments / channels that share the same defective assumption
+- Data already in the system that's silently corrupted by the same cause
+
+```bash
+grep -rn "<the function/condition>" .
+git log -S"<distinctive token>"
+```
+
+Found siblings get reported alongside the primary. A "root cause" with zero siblings is suspicious — re-examine whether you stopped at a proximate cause.
+
+### 6. Propose the fix(es)
+
+Two distinct proposals, separated:
+
+1. **Symptom fix** — the smallest change that makes the reported failure stop. Useful when shipping fast matters.
+2. **Root-cause fix** — the upstream change that addresses the gap; includes sibling repairs.
+
+For each: files, approach, test coverage, blast radius, rollback story.
+
+Recommend one. The recommendation depends on urgency, risk, and whether the symptom fix would mask the cause from future detection.
+
+### 7. Prevent the class
+
+For the root-cause fix, also propose:
+
+- **A test** — unit, integration, or e2e — that would have caught this. If no test layer would catch it, that *is* a finding.
+- **A guardrail** — type, lint rule, assertion, schema constraint, code-review checklist item, monitoring alert. The goal is that this *class* of bug becomes either impossible or loud.
+- **A doc update** — if a spec, invariant, or `AGENTS.md` missed the constraint that would have flagged this, update it.
+
+"Add a test for this exact bug" is the weakest prevention. "Make this class of bug impossible to express" is the strongest. Aim higher than the floor.
+
+### 8. Report
+
+Inverted pyramid:
+
+1. **Headline** — one sentence: what broke, what the root cause was, recommended fix.
+2. **Symptom / scope** — what users saw, who was affected, when it started.
+3. **5-whys chain** — the verified chain with citations (file:line, log excerpt, commit SHA).
+4. **Symptom / proximate / root** — labelled.
+5. **Siblings** — list, with severity.
+6. **Fix proposals** — symptom fix, root-cause fix, recommendation.
+7. **Prevention** — test, guardrail, doc update.
+8. **Open questions** — anything needing user input before implementation.
+
+## Anti-rationalization table
+
+When tempted to skip a step, check whether your reasoning appears below. If it does, the answer is: do the step.
+
+| Rationalization | Why it fails here |
+|---|---|
+| "The fix is obvious, skip the RCA." | If the fix were truly obvious, the user wouldn't have invoked `/rca`. Obvious fixes go via `/plan` or a one-line edit. The invocation is the signal that depth is required. |
+| "I can't reproduce it, but I'm pretty sure I know why." | Pretty-sure-without-repro is the modal cause of "the same bug came back next week." If you can't reproduce, the deliverable is "we need a repro / better instrumentation," not a guess dressed as a finding. |
+| "Three whys is enough." | Three whys usually lands on a proximate cause. The whole point of five is to push past the comfortable stopping point. |
+| "The symptom *is* the cause — fix and ship." | The symptom is *evidence* of the cause. Fix the symptom and the cause moves to its next manifestation. |
+| "No siblings found, so the cause is local." | Or you stopped too early. Re-examine. A genuinely local root cause is possible but rare. |
+| "Adding a test for this exact case is enough prevention." | That catches the regression, not the class. Ask whether a guardrail, type, or invariant could prevent the *class* from being expressible at all. |
+| "The 5-whys chain reads fine, I don't need to verify each link." | A coherent narrative is not the same as a correct one. Verify each link against code, logs, or data. |
+| "The cause is 'the original author didn't anticipate this' — done." | That's a no-op finding. The actionable root cause is: what process / type / test / doc would have made them anticipate it? |
+| "RCA can wait, let's ship the fix first." | Fine, *if* the RCA has a deadline before the on-call rotation forgets. RCAs deferred indefinitely become RCAs never done. Set the deadline now. |
+| "I'll just `git bisect` and call the offending commit the root cause." | The commit is *where* the cause was introduced, not *what* the cause is. Bisect locates the change; the 5-whys explains why the change was wrong and what allowed it through. |
+
+## Anti-patterns
+
+- **Treating RCA as a postmortem template to fill in.** Boxes filled ≠ cause understood. The chain must be verified, not just authored.
+- **Concluding "human error."** Almost never the root cause; almost always a proximate cause. The root cause is the system that let the human err undetected.
+- **Stopping at "we didn't have a test."** Test absence is itself a symptom — of a process or design gap. Why was there no test? Why did review not catch it?
+- **Fixing siblings silently.** If you found three other places with the same cause, the user should hear about them, not discover them in the diff.
+- **Confusing a longer chain for a deeper one.** Five whys is a floor and a discipline, not a quota. Three rigorous whys beats seven hand-wavy ones.
+- **RCA-as-blame.** The output is a system change, not a person. If the report names a person, rewrite it.
+
+## Definition of done
+
+The RCA is complete when **all** of these are true. Each item is answerable with evidence — a citation, a log excerpt, a commit SHA — not a vibe.
+
+- [ ] Failure captured: symptom, scope, expected vs. actual, time window — all written down.
+- [ ] Repro or trace established; if neither, the *finding* is "we need instrumentation" and the RCA is paused, not faked.
+- [ ] Timeline reconstructed: the change(s) plausibly responsible are named, with commits / deploys / config flips cited.
+- [ ] 5-whys chain written out, each link verified against actual code / logs / data (not memory).
+- [ ] Symptom / proximate cause / root cause explicitly labelled and distinguished.
+- [ ] Sibling sweep performed; either siblings are listed, or the absence is justified.
+- [ ] Two fix proposals presented (symptom-level and root-cause-level), with a recommendation and a reason.
+- [ ] Prevention proposed: at minimum a test; ideally a guardrail or doc that prevents the *class*.
+- [ ] Report delivered inverted-pyramid, with open questions surfaced (not silently answered).
+- [ ] No "human error" conclusions. No findings that name a person rather than a system.
+
+If a checkbox cannot be ticked honestly, the RCA is not done — return to the step that produces it.
+
+## Relationship to other skills
+
+- `/super-plan` — for designing a *change*. Use after RCA when the root-cause fix is non-trivial enough to warrant deep planning.
+- `/plan` — for the symptom fix when it's small and obvious.
+- `/rebase` — unrelated; named here only so future-you doesn't conflate "regression after rebase" with "rebase failure." Regression after rebase → `/rca`; merge-conflict failure → `/rebase`.
+- The "regression CRA" referenced in `docs/guidelines.md` (per the `repo-docs` skill) is this skill, applied to a regression specifically.

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -148,6 +148,23 @@ Summarize for the user, inverted-pyramid:
 - Any spec or invariant deviations resolved, with the resolution
 - Anything the user should still verify manually
 
+## Anti-rationalization table
+
+When tempted to skip a step, check whether your reasoning appears below. If it does, the answer is: do the step.
+
+| Rationalization | Why it fails here |
+|---|---|
+| "Conflicts resolved cleanly — ship it." | Conflict markers are the visible 10%; semantic drift is the invisible 90%. A clean text merge can still violate an invariant `delta` added. |
+| "The tests passed after the rebase, so it's fine." | The tests cover what was true on `old_base`. If `delta` added new surface (new caller, new channel, new spec), the suite may not cover it yet. |
+| "Git accepted the replay, so the commits must still be correct." | Git replays text. It does not check that the *solution* still matches the *problem*. Re-read the spec on `new_base`. |
+| "`delta` didn't touch the files `curr` changes — no cross-impact." | File-level untouched ≠ semantically untouched. A renamed helper, a new invariant, a tightened type — all can invalidate `curr` without touching its files. |
+| "The original spec still applies." | Re-read it on `new_base`. Specs evolve in `delta` more often than agents assume; "still applies" should be a finding, not an assumption. |
+| "`-X theirs` / `-X ours` will clear this conflict fast." | These options hide semantic divergence in a hunk-shaped blindspot. Resolve by reading both sides. |
+| "This commit looks redundant — I'll drop it silently." | Dropping a commit is a user-visible scope decision. Surface it, get the nod, then drop. |
+| "I'll bundle the rebase-fix into the original commit." | If the fix is preserving the original intent, bundle. If it's a *new* bug fix you discovered during rebase, split — per the project's split-move-and-fix rule. |
+| "Lint/tests aren't needed; rebase didn't touch logic." | Rebase always touches logic — replaying a change against new code *is* a logic change. Run them. |
+| "Three iterations of conflict resolution is enough — push it." | If you've fought the same hunk three times, the approach itself is probably wrong on `new_base`. Stop and reframe with the user. |
+
 ## Anti-patterns
 
 - **Treating rebase as a merge-conflict exercise.** Conflict markers are the visible 10%; semantic drift is the invisible 90%.
@@ -155,3 +172,20 @@ Summarize for the user, inverted-pyramid:
 - **Bundling rebase fixes into the original commit when they're really new bug fixes.** Split them.
 - **Skipping lint/tests "because rebase didn't touch logic."** Rebase always touches logic — that's the whole point of this skill.
 - **Forcing through a Conflicting classification without surfacing it.** Stop and talk to the user.
+
+## Definition of done
+
+The rebase is complete when **all** of these are true. Each item is answerable with evidence, not a vibe.
+
+- [ ] Three points (`curr`, `old_base`, `new_base`) stated back to the user; `old_base != new_base` confirmed.
+- [ ] Every commit on `curr` carries a classification (Untouched / Adjusted / Extended / Obsolete / Conflicting) with a one-line justification.
+- [ ] Any **Conflicting** or **Obsolete** classification has been surfaced to the user and resolved — not silently dropped or force-resolved.
+- [ ] Specs, invariants, and architecture docs were re-read on `new_base` (not from memory of `old_base`).
+- [ ] Each "replay-with-edits" or "new-commit" landed as a discrete, lint-clean, test-clean commit; no `--no-verify`.
+- [ ] No `-X theirs` / `-X ours` was used to clear a conflict the agent didn't read both sides of.
+- [ ] Full lint + unit test pass on affected components. Risky commits also got an e2e check (or an explicit user-deferred note).
+- [ ] Original acceptance criteria (PR description, spec, ticket) restated and confirmed still met on the rebased branch.
+- [ ] Regression surface in `delta`-touched code that `curr` did *not* touch was sanity-checked; "nothing broken there" is a finding, not an assumption.
+- [ ] Final report delivered inverted-pyramid: headline, per-commit outcome, deviations, manual-verify list.
+
+If a checkbox cannot be ticked honestly, the rebase is not done — return to the step that produces it.

--- a/.claude/skills/repo-docs/SKILL.md
+++ b/.claude/skills/repo-docs/SKILL.md
@@ -169,6 +169,23 @@ See `templates/` in this skill directory for ready-to-fill skeletons. They embed
 - **Don't** put narrative or rationale in spec files. Each spec is a tight assertion. Rationale lives in architecture or PR descriptions.
 - **Don't** create files without confirming with the user when bootstrapping a new repo.
 
+## Definition of done
+
+The skill is complete when **all** of these are true. Each item is answerable with evidence — a file path, a grep result, a user confirmation — not a vibe.
+
+- [ ] Scope confirmed with the user *before* file creation: list of feature spec files, their prefixes, any unusual splits/combines.
+- [ ] Every file in the "Required content checklist" exists and ticks every box in its own checklist. Missing items get a TODO with a reason, not silent omission.
+- [ ] No spec describes implementation. Re-read each spec body: if it names a function, class, schema, or file, rewrite it behaviorally.
+- [ ] No spec carries a separate `**Testable:**` line. If the body isn't self-evidently testable, the body is rewritten — not annotated.
+- [ ] Every spec ID is unique within its file. Deletions leave holes; no renumbering.
+- [ ] Every invariant has an `INV-N` ID. Invariants live in `invariants.md`, not scattered into feature specs.
+- [ ] Cross-links resolve: `AGENTS.md` indexes every file under `docs/`; `docs/product-specs/README.md` indexes every feature spec; every `see INV-N` / `see XXX-N` reference points to something that exists.
+- [ ] Sizes within budget: `AGENTS.md` ~150 lines, each feature spec 5–15 items at 1–3 sentences, architecture 1–3 pages. Over-budget files are split or trimmed.
+- [ ] If the repo already had docs in this pattern, only the requested files were touched — no silent rewrites of existing structure.
+- [ ] User has been shown the final layout and asked to confirm before the skill closes.
+
+If a checkbox cannot be ticked honestly, the skill is not done — return to the step that produces it.
+
 ## Concise > comprehensive
 
 The whole point of this layout is that an agent (or human) can quickly find the doc that answers their question. Long docs defeat that purpose. Aim for:

--- a/.claude/skills/super-plan/SKILL.md
+++ b/.claude/skills/super-plan/SKILL.md
@@ -54,6 +54,14 @@ If you cannot articulate a hypothesis at all, the problem is not yet understood 
 
 If multiple candidate approaches are plausible, note them and pick one to validate first based on simplicity, risk, or fit. The others are fallbacks if validation kills the primary.
 
+**Then write down what would prove the hypothesis itself wrong** — not its individual assumptions (those come in step 3), but the *shape* of the solution. Examples:
+
+- "If reads dominate writes by 100×, a read-through cache is the wrong shape — a write-aside would be."
+- "If library X requires a long-lived TCP connection, treating it as a stateless RPC is the wrong shape."
+- "If the failure happens before request routing, anything I add in the handler is the wrong shape."
+
+A hypothesis you can't even imagine disproving isn't a hypothesis — it's a vibe with file paths. If you can't write the falsifier, the hypothesis isn't specific enough; sharpen it. Carry the falsifier into step 4 and test it alongside the assumptions.
+
 ### 3. Enumerate load-bearing assumptions
 
 Write them down explicitly. An assumption is load-bearing if the plan **stops working** when the assumption is false. Examples:
@@ -102,29 +110,52 @@ If a violation is found, the plan is not yet ready. Either change the plan or �
 
 ### 6. Cross-validate with architecture & conventions
 
-Check the proposed change against:
+Two failure modes this step catches: a plan that fights the architecture, and a plan that uses defaults from your training data instead of the project's actual conventions ("pnpm" when the repo uses yarn, "localhost:3000" when the API is on :9100, "param-style DI" when the codebase uses `vi.mock`). The second is by far the more common — and the more embarrassing, because it requires zero new thinking, just reading.
+
+**6a. Architecture.** Check the proposed change against:
 
 - **High-level architecture** — does it respect component boundaries (agent vs. portal vs. marketing)? Does it route data through the documented seams, not around them?
-- **Component-level `AGENTS.md`** — language/style/test conventions, allowed dependencies, forbidden patterns
-- **Existing patterns** — is there already a way this kind of thing is done in the repo? Reuse beats invention.
-- **Security** — authn/authz at the right layer, no secret leakage, no new attack surface, input validation at boundaries
+- **Security** — authn/authz at the right layer, no secret leakage, no new attack surface, input validation at boundaries.
 - **Scalability & cost** — is the approach linear in the right dimension? Does it create N+1 queries, runaway fan-out, unbounded memory, or surprise cost?
 - **Observability** — can we tell when it breaks in prod? Logs, metrics, traces — does the plan include them where they're load-bearing?
-- **Background work** — anything async-and-retryable should run on Hatchet, not as fire-and-forget
+- **Background work** — anything async-and-retryable should run on Hatchet (or the project's equivalent), not as fire-and-forget.
 
-If the proposal conflicts with any of these, prefer adjusting the proposal over arguing with the architecture. If you genuinely think the architecture is wrong here, say so — but as a separate conversation, not a silent deviation.
+**6b. Project conventions — read, enumerate, cite, and link to plan lines.** This is a discipline check, not a judgment call. You **must produce evidence** that you read the project's conventions docs on `HEAD`, not relied on memory or sensible defaults.
 
-### 7. Cross-validate with the existing codebase
+For each row below, name the file/section you consulted and the convention you found. If a row doesn't apply (e.g. the project has no schema migrations), say so explicitly — silent omission is the failure mode. Categories are universal; the *paths* are project-specific and must be discovered from the repo, not assumed.
 
-Even after specs and architecture clear the proposal, the *code* may not. Verify:
+| What to check | Where it lives (varies by project) | What to record |
+|---|---|---|
+| Root project conventions | `AGENTS.md` / `CLAUDE.md` / `README.md` at the repo root | One-line summary + the rules the plan touches |
+| Per-component conventions | `<component>/AGENTS.md` (or equivalent) for every component the plan modifies | Local commands, code style, allowed/forbidden patterns |
+| Package manager | Conventions doc, `package.json`, lockfile (or `Cargo.lock` / `uv.lock` / …) | `yarn` / `pnpm` / `npm` / `cargo` / `uv` — verify against the lockfile; do not default |
+| Build / test / run entry points | The project's task runner — `justfile`, `Makefile`, package scripts, `cargo` aliases, etc. | The recipes the conventions doc names as canonical (do not infer from `package.json` scripts unless that *is* the documented convention) |
+| Test framework + mocking policy | Conventions doc, sibling tests, framework config | Framework name, file-location convention (co-located vs `__tests__`), mocking style (module mocks vs param DI), coverage threshold |
+| Lint / format | Conventions doc, tool config files | Tool name (biome / eslint / ruff / rustfmt / …), per-language rules |
+| Migration / schema-change tooling (only if the plan touches schema) | Conventions doc, `migrations/` or equivalent | The exact command to scaffold a migration |
+| Ports, URLs, environment | Root conventions doc | Local dev ports/URLs — don't guess at defaults |
+| Long-running / async machinery (only if the plan touches it) | Conventions doc | Which platform handles retryable work; boundary rules |
+| Existing patterns to reuse | Sibling files in the same directory | If a pattern already exists, reuse beats invention |
+| Anything else the conventions doc flags | The conventions doc itself | Catch-all for project-specific rules not covered above |
 
-- Files the plan modifies actually exist and look the way the plan assumes
-- Functions/types the plan calls or extends have the signatures the plan expects
-- No in-flight work or recent commits already do (or block) what we're planning — `git log` the relevant area
-- Test infrastructure exists for the kind of test the plan will need
-- No "shadow" duplication: if similar logic exists elsewhere, the plan should consolidate, not branch
+**The output of this step is a bullet list inside the plan under "Project conventions to follow."** Each bullet has two parts, in this exact shape:
 
-This step often surfaces small surprises that quietly invalidate parts of the plan. Catch them now.
+> - **[`file:line`]** Convention: *what the doc says.* → **Reflected in plan:** *which plan step(s) follow it, and how.*
+
+If a convention doesn't constrain this particular plan, the right-hand side reads `Doesn't constrain this plan` plus a one-line reason. "Doesn't constrain" is a claim — defend it briefly. Silent omission is the failure mode the format exists to prevent.
+
+If the proposal conflicts with any of these, prefer adjusting the proposal over arguing with the convention. If you genuinely think the convention is wrong here, say so — but as a separate conversation, not a silent deviation.
+
+### 7. Sweep the codebase for hidden conflicts
+
+Specs and architecture clearing the proposal doesn't mean the *codebase* will. File-existence and signature checks for files the plan touches belong in step 3 as load-bearing assumptions (e.g. *"`apps/web/src/foo.ts` exports `bar(x: X): Y`"*) and get validated in step 4. This step is for *systemic* surprises that wouldn't naturally appear as bullet assumptions:
+
+- **In-flight work or recent commits** in the touched area — `git log` it. Someone else may already be doing this, or just blocked it.
+- **Shadow duplication** — similar logic elsewhere in the repo that the plan should consolidate with, not branch from.
+- **Caller-side drift** — if the plan changes a signature, contract, schema, or invariant, what *else* in the repo depends on the current shape? Grep for callers, schemas, fixtures, mocks.
+- **Test infrastructure gaps** — does the layer of test the plan needs (unit / integration / e2e) actually exist for this area, or does the plan need to bring it up?
+
+This step catches the surprises that aren't part of any single assumption but invalidate the plan in aggregate.
 
 ### 8. Loop or commit
 
@@ -137,6 +168,16 @@ After steps 4–7, one of three things is true:
 Looping is normal and expected. The skill exists *because* first hypotheses are often wrong. A clean plan on the second or third iteration beats a brittle plan on the first.
 
 Cap iterations at ~3 before pulling the user in. If after 3 rounds no hypothesis survives, the problem itself likely needs reframing — surface that.
+
+### 8.5. Counterfactual: does the plan satisfy the success criteria?
+
+Close the loop between the goal (step 1) and the plan about to be written. For each success criterion stated in step 1, name the plan step(s) that satisfy it. Land on one of:
+
+- **Confirmed** — every criterion is satisfied by at least one plan step; cite which.
+- **Confirmed with gaps** — some criteria need follow-up work or out-of-band steps; list them and surface as open questions or out-of-scope.
+- **Unconfirmed** — at least one criterion has no plan step that satisfies it. **Stop.** Either extend the plan or explicitly descope the criterion with the user's agreement.
+
+A plan whose own success criteria don't all map to plan steps is a list of activities, not a plan.
 
 ### 9. Write the plan
 
@@ -174,6 +215,7 @@ When tempted to skip or shortcut a step, check whether your reasoning appears be
 | "There's no spec for this area, so cross-validation doesn't apply." | Absence of a spec is itself a signal — either propose one or flag that this work creates undocumented behavior. Don't silently skip. |
 | "The proposed approach matches an existing pattern, so it must be fine." | Patterns get cargo-culted. Confirm the pattern still applies to *this* problem before reusing it. |
 | "I'll just batch the validations in my head as I write the plan." | If they're not written down with evidence, they're not validated — they're just asserted in a more confident tone. |
+| "TS monorepos usually use pnpm / Node servers usually run on :3000 / projects usually mock with `jest.mock`." | Defaults from training data are the most dangerous failure mode in convention-checking, because they feel right and require no work to invoke. Verify on the repo, not on the population. Pull the actual command, port, framework name from `AGENTS.md` or the relevant docs/ file. |
 
 ## Anti-patterns
 
@@ -190,11 +232,13 @@ When tempted to skip or shortcut a step, check whether your reasoning appears be
 The skill is complete when **all** of these are true. Each item should be answerable with evidence, not a vibe.
 
 - [ ] Problem statement (goal / constraints / non-goals / success criteria) restated; ambiguities resolved with the user, not invented.
-- [ ] Hypothesis stated specifically enough to be falsifiable (named files, named APIs, named flows).
+- [ ] Hypothesis stated specifically enough to be falsifiable (named files, named APIs, named flows) **and** a disconfirming observation is written down — what would prove the hypothesis itself wrong, not just its individual assumptions.
 - [ ] Every load-bearing assumption carries an evidence tag — a `file:line` citation, a quoted doc passage, a script's output, or a query result. No bare `[plausible]` or `[unverified]` tags survive into the final plan.
 - [ ] Spec cross-validation: each affected requirement is named, and the plan line that satisfies it is named. Invariants explicitly checked (or a documented deviation flagged for user sign-off).
-- [ ] Architecture & conventions cross-validation: any deviation is called out, not silent.
-- [ ] Codebase cross-validation: files the plan touches were read on `HEAD`; signatures match; no in-flight work conflicts.
+- [ ] Architecture cross-validation: any deviation is called out, not silent.
+- [ ] Project-conventions cross-validation: each universal category (root + per-component conventions, package manager, build/test/run entry points, test framework + mocking policy, lint/format, migration tooling if schema is touched, ports/URLs, async machinery if relevant, reuse patterns) enumerated with `file:line` citations inside the plan, **and each bullet links to the plan step it shapes** (or is marked `Doesn't constrain this plan` with a reason). No defaults from training data — yours or the population's — sneaking in.
+- [ ] Codebase conflict sweep performed: in-flight work, shadow duplication, caller-side drift (if signatures/schemas change), and test-infrastructure gaps all checked, with any findings reflected in the plan. (File-existence and signature checks live in the assumption list, not here.)
+- [ ] Plan-vs-success-criteria counterfactual recorded as **Confirmed**, **Confirmed-with-gaps** (gaps listed), or **Unconfirmed** — and **Unconfirmed means the plan is not ready**.
 - [ ] Plan document contains: headline, approach, ordered steps with file paths, validated assumptions with evidence, risks & mitigations, out-of-scope, open questions, test plan.
 - [ ] Open questions surfaced to the user. None silently answered.
 - [ ] If validation killed the hypothesis: the deliverable is the negative result and the reframing, not a salvaged plan.

--- a/.claude/skills/super-plan/SKILL.md
+++ b/.claude/skills/super-plan/SKILL.md
@@ -159,6 +159,22 @@ Show the plan. If there are open questions, ask them explicitly and wait. If the
 
 If the plan is approved, implementation continues under normal rules (lint, test, commit hygiene, `/submit` for PRs).
 
+## Anti-rationalization table
+
+When tempted to skip or shortcut a step, check whether your reasoning appears below. If it does, the answer is: do the step.
+
+| Rationalization | Why it fails here |
+|---|---|
+| "I already know how this library/API works." | Memory of third-party APIs decays; versions drift. Cost to confirm: minutes. Cost of being wrong: hours. Verify on the version actually in use. |
+| "This change is small enough to skip validation." | If it were that small, the user would have invoked `/plan`, not `/super-plan`. The invocation itself is the signal that validation is required. |
+| "The user is waiting — just commit to the hypothesis." | A wrong plan costs more wall-clock than a slow one. The whole reason this skill exists is to front-load the failure. |
+| "I'll validate the risky assumption while implementing." | Validation discovered mid-implementation means rework, lost commits, and (worse) silent papering-over. Validate first. |
+| "Reading the source is overkill — the docs say X." | Docs lie, code does not. For any load-bearing assumption, read the implementation. |
+| "Three iterations is taking too long, let me just ship plan v3." | Three failed iterations means the problem needs reframing, not that the plan is ready. Surface to the user. |
+| "There's no spec for this area, so cross-validation doesn't apply." | Absence of a spec is itself a signal — either propose one or flag that this work creates undocumented behavior. Don't silently skip. |
+| "The proposed approach matches an existing pattern, so it must be fine." | Patterns get cargo-culted. Confirm the pattern still applies to *this* problem before reusing it. |
+| "I'll just batch the validations in my head as I write the plan." | If they're not written down with evidence, they're not validated — they're just asserted in a more confident tone. |
+
 ## Anti-patterns
 
 - **Skipping validation because "I'm pretty sure."** That's exactly when validation pays. Memory is wrong more often than agents like to admit.
@@ -168,6 +184,22 @@ If the plan is approved, implementation continues under normal rules (lint, test
 - **Looping forever.** Three iterations should converge or escalate. Indefinite refinement is a stall, not a plan.
 - **Producing a plan when the answer is "don't do this."** If validation reveals the change shouldn't ship, the deliverable is that conclusion — not a plan that ignores it.
 - **Cross-validation theatre.** Citing a spec without showing how the plan satisfies it. Name the requirement and the line of the plan that addresses it.
+
+## Definition of done
+
+The skill is complete when **all** of these are true. Each item should be answerable with evidence, not a vibe.
+
+- [ ] Problem statement (goal / constraints / non-goals / success criteria) restated; ambiguities resolved with the user, not invented.
+- [ ] Hypothesis stated specifically enough to be falsifiable (named files, named APIs, named flows).
+- [ ] Every load-bearing assumption carries an evidence tag — a `file:line` citation, a quoted doc passage, a script's output, or a query result. No bare `[plausible]` or `[unverified]` tags survive into the final plan.
+- [ ] Spec cross-validation: each affected requirement is named, and the plan line that satisfies it is named. Invariants explicitly checked (or a documented deviation flagged for user sign-off).
+- [ ] Architecture & conventions cross-validation: any deviation is called out, not silent.
+- [ ] Codebase cross-validation: files the plan touches were read on `HEAD`; signatures match; no in-flight work conflicts.
+- [ ] Plan document contains: headline, approach, ordered steps with file paths, validated assumptions with evidence, risks & mitigations, out-of-scope, open questions, test plan.
+- [ ] Open questions surfaced to the user. None silently answered.
+- [ ] If validation killed the hypothesis: the deliverable is the negative result and the reframing, not a salvaged plan.
+
+If a checkbox cannot be ticked honestly, the skill is not done — return to the step that produces it.
 
 ## Relationship to other skills
 


### PR DESCRIPTION
## Summary
- Add new `/rca` skill for failure-first investigation — 5-whys with per-link Evidence fields, load-bearing assumptions list, synthesis-level falsification, counterfactual fix check.
- Tighten `/super-plan`: decouple from one project's docs structure (universal categories instead of repo-specific paths), add a hypothesis-level falsifier, add a plan-vs-success-criteria counterfactual, refocus step 7 on systemic codebase conflicts.
- Both skills now have a DoD that enforces the new artifacts — boxes can't be ticked on vibes.
- Misc earlier work: DoD + anti-rationalization tables added across skills; initial `/rca` skill draft.

## Test plan
- [ ] Invoke `/rca` on a real regression — verify the numbered-list 5-whys with populated Evidence fields is produced, and that `UNVERIFIED` links surface rather than getting buried.
- [ ] Invoke `/super-plan` on a non-trivial change in a non-Scutebox repo — verify the convention sweep doesn't pull in irrelevant rows (no \`docs/hatchet.md\` etc.) and that the bullets link conventions to plan lines.
- [ ] Confirm the counterfactual landing state (Confirmed / Confirmed-with-gaps-or-survivors / Unconfirmed) appears in both skills' outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)