### PR TITLE
Add scripted MacBook bootstrap

### DIFF
--- a/.korya.d/Brewfile
+++ b/.korya.d/Brewfile
@@ -1,0 +1,86 @@
+# Brewfile — install everything with `brew bundle --file ~/Brewfile`.
+# Idempotent and re-runnable: existing packages are skipped.
+
+# ----------------------------------------------------------------------------
+# GNU coreutils & friends — replace the ancient BSD tools macOS ships with the
+# GNU versions the rest of the world (and most scripts) assume.
+# ----------------------------------------------------------------------------
+brew "coreutils"      # ls, cat, cp, ... (GNU); installs g-prefixed binaries
+brew "binutils"       # ld, objdump, nm, strings, ...
+brew "diffutils"      # GNU diff/cmp
+brew "findutils"      # GNU find/xargs/locate
+brew "gawk"           # GNU awk
+brew "gnu-indent"     # C source code formatter (`gindent`)
+brew "gnu-sed"        # GNU sed (`gsed`) — supports -i without an arg, etc.
+brew "gnu-tar"        # GNU tar (`gtar`)
+brew "gnu-which"      # GNU which
+brew "gnutls"         # TLS library + certtool
+brew "grep"           # GNU grep (`ggrep`) — PCRE, --color, etc.
+brew "gzip"
+brew "ed"             # the classic line editor (macOS ships an old one)
+brew "moreutils"      # handy extras: sponge, ts, vidir, parallel, ...
+brew "gpatch"         # GNU patch
+brew "m4"             # macro processor (autotools dependency)
+brew "make"           # GNU make (macOS's is years behind)
+brew "cmake"
+brew "file-formula"   # `file` — type detection (formula renamed to avoid clash)
+brew "wdiff"          # word-by-word diff
+
+# ----------------------------------------------------------------------------
+# Shell & core CLI
+# ----------------------------------------------------------------------------
+brew "bash"               # modern bash 5+ (macOS is stuck on 3.2 for licensing)
+brew "bash-completion@2"  # programmable completion for bash 4+
+brew "less"
+brew "wget"
+brew "curl"
+brew "socat"          # multipurpose socket relay — netcat on steroids
+brew "git"
+brew "openssh"
+brew "python"
+brew "rsync"
+brew "svn"            # subversion — still needed by some brew casks/legacy repos
+brew "unzip"
+brew "tree"
+brew "rename"         # Perl-based bulk file renamer
+brew "watch"          # re-run a command periodically, full-screen
+
+# ----------------------------------------------------------------------------
+# Crypto / security
+# ----------------------------------------------------------------------------
+brew "gpg2"           # GnuPG — referenced by ~/.gitconfig for commit signing
+
+# ----------------------------------------------------------------------------
+# Productivity / modern CLI
+# ----------------------------------------------------------------------------
+brew "jq"             # command-line JSON processor
+brew "just"           # command runner — a saner `make` for project tasks
+brew "ag"             # the_silver_searcher — fast recursive code grep
+brew "fzf"            # fuzzy finder (Ctrl-R / Ctrl-T); run its install once
+brew "zellij"         # terminal multiplexer (a friendlier tmux)
+brew "gh"             # GitHub CLI — also used to upload the SSH key
+brew "bat"            # `cat` with syntax highlighting + git integration
+brew "dockutil"       # script the macOS Dock contents (used by macos.sh)
+brew "docker-credential-helper"  # stores Docker registry creds in the keychain
+
+# ----------------------------------------------------------------------------
+# Editors
+# ----------------------------------------------------------------------------
+brew "macvim"         # Vim w/ GUI — provides `gvim`, used as git's editor/difftool
+brew "nvim"           # Neovim
+
+# ----------------------------------------------------------------------------
+# GUI apps (casks)
+# ----------------------------------------------------------------------------
+cask "iterm2"
+cask "docker"                 # Docker Desktop
+cask "visual-studio-code"
+cask "cursor"                 # AI-integrated VS Code fork
+cask "windsurf"               # AI-integrated editor
+cask "bitwarden"              # password manager
+cask "tailscale"              # WireGuard-based mesh VPN
+
+# ----------------------------------------------------------------------------
+# Fonts
+# ----------------------------------------------------------------------------
+cask "font-hack-nerd-font"    # patched Hack font w/ glyphs for the p10k prompt

--- a/.korya.d/bootstrap.sh
+++ b/.korya.d/bootstrap.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# bootstrap.sh — set up a fresh macOS machine end to end.
+#
+#   bash <(curl -fsSL https://raw.githubusercontent.com/korya/dotfiles/master/.korya.d/bootstrap.sh)
+#
+# Steps, in order:
+#   1. Xcode Command Line Tools (provides a real git)
+#   2. Install the dotfiles into $HOME       (.korya.d/install-dotfiles.sh)
+#   3. Homebrew
+#   4. Everything from the Brewfile          (.korya.d/Brewfile)
+#   5. macOS UI defaults + Dock cleanup      (.korya.d/macos.sh)
+#   6. Editor plugins (vim-plug, LazyVim)
+#
+# Idempotent: each step checks before acting, so re-running is safe.
+#
+set -euo pipefail
+
+RAW_BASE="https://raw.githubusercontent.com/korya/dotfiles/master/.korya.d"
+
+# Run a .korya.d/ script, preferring the local copy (present once the dotfiles
+# are installed) and falling back to fetching it over the network.
+run_korya_script() {
+  local name="$1"; shift
+  if [ -f "$HOME/.korya.d/$name" ]; then
+    bash "$HOME/.korya.d/$name" "$@"
+  else
+    bash <(curl -fsSL "$RAW_BASE/$name") "$@"
+  fi
+}
+
+step() { printf '\n\033[1;34m==>\033[0m %s\n' "$1"; }
+
+# --- 1. Xcode Command Line Tools ---------------------------------------------
+step "Xcode Command Line Tools"
+if xcode-select -p >/dev/null 2>&1; then
+  echo "Already installed."
+else
+  echo "Triggering install — accept the dialog that appears, then wait…"
+  xcode-select --install || true
+  until xcode-select -p >/dev/null 2>&1; do sleep 5; done
+  echo "Installed."
+fi
+
+# --- 2. Dotfiles -------------------------------------------------------------
+step "Dotfiles"
+run_korya_script install-dotfiles.sh
+
+# --- 3. Homebrew -------------------------------------------------------------
+step "Homebrew"
+if ! command -v brew >/dev/null 2>&1; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+# Put brew on PATH for the rest of this script.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# --- 4. Brewfile -------------------------------------------------------------
+step "Packages (brew bundle)"
+brew bundle --file "$HOME/.korya.d/Brewfile"
+
+# --- 5. macOS defaults -------------------------------------------------------
+step "macOS defaults"
+run_korya_script macos.sh
+
+# --- 6. Editor plugins -------------------------------------------------------
+step "Editor plugins"
+if command -v vim >/dev/null 2>&1; then
+  vim +PlugInstall +qall || echo "vim plugin install hiccup — run ':PlugInstall' by hand." >&2
+fi
+if command -v nvim >/dev/null 2>&1; then
+  nvim --headless "+Lazy! sync" +qa || echo "nvim plugin sync hiccup — open nvim to finish." >&2
+fi
+
+# --- 7. SSH key --------------------------------------------------------------
+step "SSH key"
+if [ -f "$HOME/.ssh/id_ed25519" ]; then
+  echo "Key already exists."
+else
+  echo "Generating an ed25519 key (you'll be asked for a passphrase)…"
+  ssh-keygen -o -a 256 -t ed25519 -C "${USER}@$(hostname -s)" -f "$HOME/.ssh/id_ed25519"
+fi
+
+# --- Done --------------------------------------------------------------------
+cat <<'EOF'
+
+All scripted steps done. A few things still need a human:
+  • Restart the shell (or `exec zsh`) to load the new environment.
+  • System permissions: grant Docker and Tailscale access when prompted.
+  • Add Russian/Hebrew input sources, set Caps Lock -> Escape (Settings > Keyboard).
+  • Upload your SSH key to GitHub:
+      gh auth login
+      gh ssh-key add ~/.ssh/id_ed25519.pub -t "$(hostname -s)"
+EOF

--- a/.korya.d/install-dotfiles.sh
+++ b/.korya.d/install-dotfiles.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# install-dotfiles.sh — turn $HOME into the dotfiles git repo, without the
+# manual merge-conflict dance.
+#
+# macOS seeds a fresh account with its own .zshrc, .zprofile, etc. A naive
+# `git pull` into $HOME then refuses to overwrite those untracked files. So we
+# move every file the repo tracks out of the way (into a timestamped backup)
+# and only then check the branch out clean.
+#
+# Idempotent: re-running just fast-forwards the already-initialized repo.
+#
+set -euo pipefail
+
+REPO="${DOTFILES_REPO:-https://github.com/korya/dotfiles}"
+BRANCH="${DOTFILES_BRANCH:-master}"
+
+cd "$HOME"
+
+# --- Already set up? Just update and bail. ---
+if [ -d "$HOME/.git" ] && git rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  echo "Dotfiles repo already initialized — fast-forwarding."
+  git fetch -q origin "$BRANCH"
+  git checkout -q "$BRANCH"
+  git pull -q --ff-only origin "$BRANCH" \
+    || echo "Could not fast-forward; resolve manually with 'git status'." >&2
+  exit 0
+fi
+
+# --- Fresh install. ---
+[ -d .git ] || git init -q
+git remote add origin "$REPO" 2>/dev/null || git remote set-url origin "$REPO"
+git fetch -q origin "$BRANCH"
+
+# Move aside any pre-existing files the checkout would clobber.
+backup="$HOME/.dotfiles-backup-$(date +%Y%m%d-%H%M%S)"
+while IFS= read -r f; do
+  [ -e "$HOME/$f" ] || continue
+  mkdir -p "$backup/$(dirname "$f")"
+  mv "$HOME/$f" "$backup/$f"
+done < <(git ls-tree -r --name-only "origin/$BRANCH")
+
+# Adopt the branch (safe now — nothing left to conflict with).
+git checkout -B "$BRANCH" "origin/$BRANCH"
+git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
+
+if [ -d "$backup" ]; then
+  echo "Done. Pre-existing files backed up to: $backup"
+else
+  echo "Done."
+fi

--- a/.korya.d/macos.sh
+++ b/.korya.d/macos.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# macos.sh — apply my preferred macOS UI defaults.
+# Idempotent: safe to re-run. Run with `bash ~/.korya.d/macos.sh`.
+#
+set -euo pipefail
+
+# --- Trackpad ---
+# Enable "Tap to click" (current host + global so it sticks before login too).
+defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
+defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
+defaults write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
+
+# --- Dock ---
+# Move the Dock to the left — frees up the precious center of the screen.
+defaults write com.apple.dock orientation -string "left"
+
+# Enable magnification at a mid-level size (tweak largesize to taste).
+defaults write com.apple.dock magnification -bool true
+defaults write com.apple.dock largesize -int 64
+
+# Auto-hide the Dock — out of sight until needed.
+defaults write com.apple.dock autohide -bool true
+
+# --- Desktops (Spaces) ---
+# Stop macOS from reordering Spaces by most-recent-use (keeps ^1/^2 stable).
+defaults write com.apple.dock mru-spaces -bool false
+
+# --- Dock contents ---
+# Wipe the stock app shortcuts and keep only what I use. Finder stays pinned by
+# the system, so it doesn't need adding. (Launchpad.app was removed in macOS 26.)
+if command -v dockutil >/dev/null 2>&1; then
+  dockutil --no-restart --remove all >/dev/null
+  for app in /Applications/Safari.app /System/Applications/Notes.app; do
+    [ -e "$app" ] && dockutil --no-restart --add "$app" >/dev/null
+  done
+else
+  echo "dockutil not found — skipping Dock cleanup (install via the Brewfile)." >&2
+fi
+
+# --- Apply changes ---
+# Restart the Dock so all of the above takes effect immediately.
+killall Dock
+
+echo "macOS defaults applied. Some settings may need a logout to fully apply."

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-Install the dotfiles
+# dotfiles
+
+Install the dotfiles — turns `$HOME` into this repo, backing up any files
+macOS pre-seeded (`.zshrc`, `.zprofile`, …) instead of forcing a manual merge:
 
 ```sh
-cd ~
-git init .
-git remote add origin https://github.com/korya/dotfiles
-git pull origin master
+bash <(curl -fsSL https://raw.githubusercontent.com/korya/dotfiles/master/.korya.d/install-dotfiles.sh)
 ```
 
-Note: unfortunately, all conflicts need to be resolved manually.
+Pre-existing files are moved to `~/.dotfiles-backup-<timestamp>/`. The script is
+idempotent: re-running just fast-forwards the repo.


### PR DESCRIPTION
## What

Collapses the manual [MacBook setup guide](https://korya.dev/posts/2025-02-05---setup-macbook) into a set of re-runnable scripts under `.korya.d/`, so a fresh machine is provisioned with **one command** instead of copy-pasting through six sections:

```sh
bash <(curl -fsSL https://raw.githubusercontent.com/korya/dotfiles/master/.korya.d/bootstrap.sh)
```

## Changes

- **`.korya.d/Brewfile`** — single `brew bundle` manifest replacing the scattered `brew install` lines, with comments on the non-obvious formulae.
- **`.korya.d/install-dotfiles.sh`** — turns `$HOME` into the repo by backing up macOS-seeded files (`.zshrc`, `.zprofile`, …) into `~/.dotfiles-backup-<timestamp>/` first, eliminating the manual merge-conflict resolution. Sandbox-tested.
- **`.korya.d/macos.sh`** — bundles the trackpad / dock / spaces `defaults write` calls plus a `dockutil`-based Dock cleanup (keeps Finder, Safari, Notes; Launchpad is gone in macOS 26).
- **`.korya.d/bootstrap.sh`** — chains everything: Xcode CLT → dotfiles → Homebrew → `brew bundle` → `macos.sh` → editor plugins (vim-plug + LazyVim, headless) → SSH key. Idempotent and self-fetching.
- **`README.md`** — points at the new installer.

## Notes

- Ordering dependencies are encoded in `bootstrap.sh` (dotfiles before `brew bundle`; `brew bundle` before `macos.sh` so `dockutil` exists).
- The legacy `fzf/install` step was dropped — the dotfiles already wire fzf via `source <(fzf --zsh)` and `.fzf.bash`.
- Genuinely manual remainders (Docker/Tailscale permission grants, input sources, `gh ssh-key add`) are printed at the end of the run rather than silently skipped.
- A matching guide rewrite on korya.dev is pending (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)