### PR TITLE
Harden install-dotfiles.sh + add tracing/logging to setup scripts

### DIFF
--- a/.korya.d/bootstrap.sh
+++ b/.korya.d/bootstrap.sh
@@ -11,35 +11,50 @@
 #   4. Everything from the Brewfile          (.korya.d/Brewfile)
 #   5. macOS UI defaults + Dock cleanup      (.korya.d/macos.sh)
 #   6. Editor plugins (vim-plug, LazyVim)
+#   7. SSH key
 #
 # Idempotent: each step checks before acting, so re-running is safe.
+# Run with DEBUG=1 to trace every command.
 #
 set -euo pipefail
 
 RAW_BASE="https://raw.githubusercontent.com/korya/dotfiles/master/.korya.d"
+
+# --- logging ---
+step() { printf '\n\033[1;34m==>\033[0m \033[1m%s\033[0m\n' "$1"; }
+log()  { printf '\033[0;34m  ▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m  ✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m  ! %s\033[0m\n' "$*" >&2; }
+[ -n "${DEBUG:-}" ] && set -x
+
+log "Starting bootstrap on $(hostname -s) at $(date '+%Y-%m-%d %H:%M:%S')"
+[ -n "${DEBUG:-}" ] && log "DEBUG on — tracing every command."
 
 # Run a .korya.d/ script, preferring the local copy (present once the dotfiles
 # are installed) and falling back to fetching it over the network.
 run_korya_script() {
   local name="$1"; shift
   if [ -f "$HOME/.korya.d/$name" ]; then
+    log "Running local ~/.korya.d/$name"
     bash "$HOME/.korya.d/$name" "$@"
   else
+    log "Fetching and running $name from $RAW_BASE"
     bash <(curl -fsSL "$RAW_BASE/$name") "$@"
   fi
 }
 
-step() { printf '\n\033[1;34m==>\033[0m %s\n' "$1"; }
-
 # --- 1. Xcode Command Line Tools ---------------------------------------------
 step "Xcode Command Line Tools"
 if xcode-select -p >/dev/null 2>&1; then
-  echo "Already installed."
+  ok "Already installed ($(xcode-select -p))."
 else
-  echo "Triggering install — accept the dialog that appears, then wait…"
+  log "Triggering install — accept the dialog that appears, then wait..."
   xcode-select --install || true
-  until xcode-select -p >/dev/null 2>&1; do sleep 5; done
-  echo "Installed."
+  until xcode-select -p >/dev/null 2>&1; do
+    log "Waiting for Command Line Tools to finish installing..."
+    sleep 5
+  done
+  ok "Installed."
 fi
 
 # --- 2. Dotfiles -------------------------------------------------------------
@@ -48,19 +63,30 @@ run_korya_script install-dotfiles.sh
 
 # --- 3. Homebrew -------------------------------------------------------------
 step "Homebrew"
-if ! command -v brew >/dev/null 2>&1; then
+if command -v brew >/dev/null 2>&1; then
+  ok "Already installed ($(command -v brew))."
+else
+  log "Installing Homebrew (this can take a few minutes)..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  ok "Homebrew installed."
 fi
 # Put brew on PATH for the rest of this script.
 if [ -x /opt/homebrew/bin/brew ]; then
+  log "Loading brew shellenv from /opt/homebrew (Apple Silicon)."
   eval "$(/opt/homebrew/bin/brew shellenv)"
 elif [ -x /usr/local/bin/brew ]; then
+  log "Loading brew shellenv from /usr/local (Intel)."
   eval "$(/usr/local/bin/brew shellenv)"
+else
+  warn "Could not locate the brew binary on the expected paths."
 fi
 
 # --- 4. Brewfile -------------------------------------------------------------
 step "Packages (brew bundle)"
-brew bundle --file "$HOME/.korya.d/Brewfile"
+brewfile="$HOME/.korya.d/Brewfile"
+log "Installing from $brewfile ($(grep -cE '^(brew|cask|mas) ' "$brewfile" 2>/dev/null || echo '?') entries)..."
+brew bundle --file "$brewfile"
+ok "Packages installed."
 
 # --- 5. macOS defaults -------------------------------------------------------
 step "macOS defaults"
@@ -69,24 +95,29 @@ run_korya_script macos.sh
 # --- 6. Editor plugins -------------------------------------------------------
 step "Editor plugins"
 if command -v vim >/dev/null 2>&1; then
-  vim +PlugInstall +qall || echo "vim plugin install hiccup — run ':PlugInstall' by hand." >&2
+  log "Installing vim-plug plugins (headless)..."
+  vim +PlugInstall +qall && ok "vim plugins installed." \
+    || warn "vim plugin install hiccup — run ':PlugInstall' by hand."
 fi
 if command -v nvim >/dev/null 2>&1; then
-  nvim --headless "+Lazy! sync" +qa || echo "nvim plugin sync hiccup — open nvim to finish." >&2
+  log "Syncing LazyVim plugins (headless)..."
+  nvim --headless "+Lazy! sync" +qa && ok "nvim plugins synced." \
+    || warn "nvim plugin sync hiccup — open nvim to finish."
 fi
 
 # --- 7. SSH key --------------------------------------------------------------
 step "SSH key"
 if [ -f "$HOME/.ssh/id_ed25519" ]; then
-  echo "Key already exists."
+  ok "Key already exists ($HOME/.ssh/id_ed25519)."
 else
-  echo "Generating an ed25519 key (you'll be asked for a passphrase)…"
+  log "Generating an ed25519 key (you'll be asked for a passphrase)..."
   ssh-keygen -o -a 256 -t ed25519 -C "${USER}@$(hostname -s)" -f "$HOME/.ssh/id_ed25519"
+  ok "Key generated."
 fi
 
 # --- Done --------------------------------------------------------------------
+step "Done"
 cat <<'EOF'
-
 All scripted steps done. A few things still need a human:
   • Restart the shell (or `exec zsh`) to load the new environment.
   • System permissions: grant Docker and Tailscale access when prompted.

--- a/.korya.d/install-dotfiles.sh
+++ b/.korya.d/install-dotfiles.sh
@@ -15,16 +15,26 @@ set -euo pipefail
 REPO="${DOTFILES_REPO:-https://github.com/korya/dotfiles}"
 BRANCH="${DOTFILES_BRANCH:-master}"
 
+# Normalize a git URL (https or ssh, with/without .git) to "owner/repo".
+slug() { printf '%s\n' "$1" | sed -E 's#\.git$##; s#^.*[/:]([^/]+/[^/]+)$#\1#'; }
+
 cd "$HOME"
 
-# --- Already set up? Just update and bail. ---
-if [ -d "$HOME/.git" ] && git rev-parse --verify -q HEAD >/dev/null 2>&1; then
-  echo "Dotfiles repo already initialized — fast-forwarding."
-  git fetch -q origin "$BRANCH"
-  git checkout -q "$BRANCH"
-  git pull -q --ff-only origin "$BRANCH" \
-    || echo "Could not fast-forward; resolve manually with 'git status'." >&2
-  exit 0
+# --- Already a git repo? Don't touch it. ---
+# This installer is for a *fresh* machine. On a machine that already has the
+# dotfiles checked out into $HOME — possibly on a personal branch with local
+# changes — silently switching branches or hard-resetting would be destructive.
+# So we refuse and let the user update on their own terms.
+if [ -d "$HOME/.git" ]; then
+  existing="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -n "$existing" ] && [ "$(slug "$existing")" = "$(slug "$REPO")" ]; then
+    echo "\$HOME is already a checkout of $(slug "$REPO") — nothing to do."
+    echo "To update, manage it yourself, e.g.: git -C \"\$HOME\" pull"
+    exit 0
+  fi
+  echo "Refusing: \$HOME is already a git repo (origin: ${existing:-none})." >&2
+  echo "Move it aside or install manually if that's intentional." >&2
+  exit 1
 fi
 
 # --- Fresh install. ---

--- a/.korya.d/install-dotfiles.sh
+++ b/.korya.d/install-dotfiles.sh
@@ -8,16 +8,25 @@
 # move every file the repo tracks out of the way (into a timestamped backup)
 # and only then check the branch out clean.
 #
-# Idempotent: re-running just fast-forwards the already-initialized repo.
+# On a machine that already has the dotfiles, this refuses to touch them.
+#
+# Run with DEBUG=1 to trace every command.
 #
 set -euo pipefail
 
 REPO="${DOTFILES_REPO:-https://github.com/korya/dotfiles}"
 BRANCH="${DOTFILES_BRANCH:-master}"
 
+# --- logging ---
+log()  { printf '\033[0;34m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m! %s\033[0m\n' "$*" >&2; }
+[ -n "${DEBUG:-}" ] && set -x
+
 # Normalize a git URL (https or ssh, with/without .git) to "owner/repo".
 slug() { printf '%s\n' "$1" | sed -E 's#\.git$##; s#^.*[/:]([^/]+/[^/]+)$#\1#'; }
 
+log "Installing $(slug "$REPO") (branch: $BRANCH) into \$HOME ($HOME)"
 cd "$HOME"
 
 # --- Already a git repo? Don't touch it. ---
@@ -26,36 +35,47 @@ cd "$HOME"
 # changes — silently switching branches or hard-resetting would be destructive.
 # So we refuse and let the user update on their own terms.
 if [ -d "$HOME/.git" ]; then
+  log "\$HOME is already a git repo — inspecting its origin..."
   existing="$(git remote get-url origin 2>/dev/null || true)"
   if [ -n "$existing" ] && [ "$(slug "$existing")" = "$(slug "$REPO")" ]; then
-    echo "\$HOME is already a checkout of $(slug "$REPO") — nothing to do."
-    echo "To update, manage it yourself, e.g.: git -C \"\$HOME\" pull"
+    ok "Already a checkout of $(slug "$REPO") — nothing to do."
+    log "To update, manage it yourself, e.g.: git -C \"\$HOME\" pull"
     exit 0
   fi
-  echo "Refusing: \$HOME is already a git repo (origin: ${existing:-none})." >&2
-  echo "Move it aside or install manually if that's intentional." >&2
+  warn "Refusing: \$HOME is a git repo for a different origin (${existing:-none})."
+  warn "Move it aside or install manually if that's intentional."
   exit 1
 fi
 
 # --- Fresh install. ---
+log "Initializing git in \$HOME and wiring up the remote..."
 [ -d .git ] || git init -q
 git remote add origin "$REPO" 2>/dev/null || git remote set-url origin "$REPO"
+
+log "Fetching origin/$BRANCH..."
 git fetch -q origin "$BRANCH"
 
 # Move aside any pre-existing files the checkout would clobber.
+log "Backing up any pre-existing tracked files..."
 backup="$HOME/.dotfiles-backup-$(date +%Y%m%d-%H%M%S)"
+n=0
 while IFS= read -r f; do
   [ -e "$HOME/$f" ] || continue
   mkdir -p "$backup/$(dirname "$f")"
   mv "$HOME/$f" "$backup/$f"
+  log "  backed up: $f"
+  n=$((n + 1))
 done < <(git ls-tree -r --name-only "origin/$BRANCH")
+if [ "$n" -gt 0 ]; then
+  log "Moved $n pre-existing file(s) to $backup"
+else
+  log "No pre-existing files to back up."
+fi
 
 # Adopt the branch (safe now — nothing left to conflict with).
-git checkout -B "$BRANCH" "origin/$BRANCH"
+log "Checking out $BRANCH into \$HOME..."
+git checkout -B "$BRANCH" "origin/$BRANCH" >/dev/null 2>&1
 git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
 
-if [ -d "$backup" ]; then
-  echo "Done. Pre-existing files backed up to: $backup"
-else
-  echo "Done."
-fi
+ok "Dotfiles installed."
+[ "$n" -gt 0 ] && log "Your previous files are preserved in: $backup"

--- a/.korya.d/macos.sh
+++ b/.korya.d/macos.sh
@@ -2,27 +2,35 @@
 #
 # macos.sh — apply my preferred macOS UI defaults.
 # Idempotent: safe to re-run. Run with `bash ~/.korya.d/macos.sh`.
+# Run with DEBUG=1 to trace every command.
 #
 set -euo pipefail
 
+# --- logging ---
+log()  { printf '\033[0;34m▸\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m! %s\033[0m\n' "$*" >&2; }
+[ -n "${DEBUG:-}" ] && set -x
+
 # --- Trackpad ---
+log "Trackpad: enabling tap-to-click..."
 # Enable "Tap to click" (current host + global so it sticks before login too).
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 defaults write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 
 # --- Dock ---
+log "Dock: moving left, magnification on, auto-hide on..."
 # Move the Dock to the left — frees up the precious center of the screen.
 defaults write com.apple.dock orientation -string "left"
-
 # Enable magnification at a mid-level size (tweak largesize to taste).
 defaults write com.apple.dock magnification -bool true
 defaults write com.apple.dock largesize -int 64
-
 # Auto-hide the Dock — out of sight until needed.
 defaults write com.apple.dock autohide -bool true
 
 # --- Desktops (Spaces) ---
+log "Spaces: disabling most-recent-use reordering..."
 # Stop macOS from reordering Spaces by most-recent-use (keeps ^1/^2 stable).
 defaults write com.apple.dock mru-spaces -bool false
 
@@ -30,16 +38,20 @@ defaults write com.apple.dock mru-spaces -bool false
 # Wipe the stock app shortcuts and keep only what I use. Finder stays pinned by
 # the system, so it doesn't need adding. (Launchpad.app was removed in macOS 26.)
 if command -v dockutil >/dev/null 2>&1; then
+  log "Dock: clearing stock apps, keeping Safari + Notes..."
   dockutil --no-restart --remove all >/dev/null
   for app in /Applications/Safari.app /System/Applications/Notes.app; do
-    [ -e "$app" ] && dockutil --no-restart --add "$app" >/dev/null
+    if [ -e "$app" ]; then
+      dockutil --no-restart --add "$app" >/dev/null
+      log "  added: $app"
+    fi
   done
 else
-  echo "dockutil not found — skipping Dock cleanup (install via the Brewfile)." >&2
+  warn "dockutil not found — skipping Dock cleanup (install via the Brewfile)."
 fi
 
 # --- Apply changes ---
-# Restart the Dock so all of the above takes effect immediately.
+log "Restarting Dock to apply changes..."
 killall Dock
 
-echo "macOS defaults applied. Some settings may need a logout to fully apply."
+ok "macOS defaults applied. Some settings may need a logout to fully apply."


### PR DESCRIPTION
Two related improvements to the `.korya.d/` setup scripts.

## 1. Make `install-dotfiles.sh` safe on already-installed machines

The installer is for a **fresh machine**, but its old "already initialized" path force-checked-out the target branch and tried to fast-forward — destructive on a machine that already has the dotfiles on a personal branch with local changes, and confusing in practice (ran on an existing checkout, left `HEAD` untouched, yet printed success).

Now: if `$HOME` is already a git repo it **refuses to touch it**.
- **Same repo** (origin normalizes to `korya/dotfiles` via a new `slug()` helper handling https / `.git` / ssh) → "nothing to do", exit `0`.
- **Different repo** → refuse, exit `1`.

The fresh-install path is unchanged.

## 2. Step-by-step logging + `DEBUG` tracing across all three scripts

So a run is easy to follow and troubleshoot:
- Consistent helpers in each script: `▸` step, `✓` success, `!` warning.
- Each action is announced before it runs, with result counts (files backed up, Brewfile entries, etc.).
- **`DEBUG=1`** turns on full `set -x` command tracing in `bootstrap.sh`, `install-dotfiles.sh`, and `macos.sh`.

Also fixes a latent bug the sandbox caught: a Unicode ellipsis abutting `"$BRANCH"` was mis-parsed under `set -u` as an unbound variable. All ellipses are now ASCII `...`.

## Testing

Sandbox-tested `install-dotfiles.sh` against a throwaway `HOME` + fake remote, normal and `DEBUG=1`:

| Case | Result |
|------|--------|
| Fresh `$HOME` (stock `.zshrc`) | Backs up stock file, populates from repo, exit 0 |
| Already installed, same repo | "nothing to do", exit 0 |
| `$HOME` is a different git repo | Refuses, exit 1 |

`bootstrap.sh` / `macos.sh` syntax-checked (not executed — `macos.sh` mutates live system defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)