### PR TITLE
Fix vim first-run colorscheme hang in bootstrap

### DIFF
--- a/.korya.d/bootstrap.sh
+++ b/.korya.d/bootstrap.sh
@@ -96,12 +96,14 @@ run_korya_script macos.sh
 step "Editor plugins"
 if command -v vim >/dev/null 2>&1; then
   log "Installing vim-plug plugins (headless)..."
-  vim +PlugInstall +qall && ok "vim plugins installed." \
+  # --sync so install finishes before quit; qall! + </dev/null so a stray
+  # startup prompt can never block the bootstrap.
+  vim +'PlugInstall --sync' +qall! </dev/null && ok "vim plugins installed." \
     || warn "vim plugin install hiccup — run ':PlugInstall' by hand."
 fi
 if command -v nvim >/dev/null 2>&1; then
   log "Syncing LazyVim plugins (headless)..."
-  nvim --headless "+Lazy! sync" +qa && ok "nvim plugins synced." \
+  nvim --headless "+Lazy! sync" +qa </dev/null && ok "nvim plugins synced." \
     || warn "nvim plugin sync hiccup — open nvim to finish."
 fi
 

--- a/.vimrc
+++ b/.vimrc
@@ -275,7 +275,9 @@ Plug 'github/copilot.vim'
 call plug#end()
 " }}}
 
-colorscheme solarized
+" silent! so the very first launch (before plugins are installed) doesn't error
+" out with E185 and block on a 'Press ENTER' prompt during headless PlugInstall.
+silent! colorscheme solarized
 set background=dark
 
 " PLUGIN: ctrl-p {{{


### PR DESCRIPTION
## Why

Caught during a real bootstrap run: the headless `vim +PlugInstall` step hung on a `Press ENTER` prompt:

```
Error detected while processing /Users/dmitri/.vimrc:
line  278:
E185: Cannot find color scheme 'solarized'
Press ENTER or type command to continue
```

On a fresh machine `.vimrc` runs `colorscheme solarized` **before** the plugin that provides it (`altercation/vim-colors-solarized`) is installed, so Vim raises `E185` and shows an interactive hit-enter prompt — which blocks the headless install.

## What

- **`.vimrc`** → `silent! colorscheme solarized`. The missing scheme is ignored on first launch and loads normally once plugins are installed.
- **`bootstrap.sh`** → run the plugin install with `+'PlugInstall --sync'`, `+qall!`, and `</dev/null` (and `</dev/null` on the nvim sync too) so no startup prompt can ever stall the run again.

## Notes

- Existing machines self-heal: pressing ENTER lets `PlugInstall` finish, after which the colorscheme exists and the error never recurs.
- `silent!` verified to suppress the error without a prompt; `bootstrap.sh` syntax-checked. The real `PlugInstall` wasn't executed in-session (it would touch a live `~/.vim`).

Follow-up to #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)