### PR TITLE
Brewfile: swap VS Code/Cursor/Windsurf for Zed + codex + claude-code

### DIFF
--- a/.korya.d/Brewfile
+++ b/.korya.d/Brewfile
@@ -74,11 +74,15 @@ brew "nvim"           # Neovim
 # ----------------------------------------------------------------------------
 cask "iterm2"
 cask "docker"                 # Docker Desktop
-cask "visual-studio-code"
-cask "cursor"                 # AI-integrated VS Code fork
-cask "windsurf"               # AI-integrated editor
+cask "zed"                    # Zed editor
 cask "bitwarden"              # password manager
 cask "tailscale"              # WireGuard-based mesh VPN
+
+# ----------------------------------------------------------------------------
+# AI coding agents (casks)
+# ----------------------------------------------------------------------------
+cask "claude-code"            # Claude Code — terminal AI coding assistant
+cask "codex"                  # OpenAI's terminal coding agent
 
 # ----------------------------------------------------------------------------
 # Fonts


### PR DESCRIPTION
## What

Updates the editor/IDE set in `.korya.d/Brewfile`.

**Removed casks:**
- `visual-studio-code`
- `cursor`
- `windsurf`

**Added casks:**
- `zed` — Zed editor
- `claude-code` — Claude Code, terminal AI coding assistant
- `codex` — OpenAI's terminal coding agent

The two CLI agents go under a new `# AI coding agents (casks)` group to keep the section header honest (they're terminal tools, not GUI apps).

## Verification

All three new identifiers confirmed as valid Homebrew casks (`brew info --cask`), and the Brewfile re-parses cleanly via `brew bundle list --cask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)