### PR TITLE
nvim: remove unused Codeium extra (it hung headless plugin sync)

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -8,7 +8,6 @@
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
   "catppuccin": { "branch": "main", "commit": "426dbebe06b5c69fd846ceb17b42e12f890aedf1" },
   "cmake-tools.nvim": { "branch": "master", "commit": "f9a3eb2be0b8148df470244e5c25aede3a3a28a5" },
-  "codeium.nvim": { "branch": "main", "commit": "821b570b526dbb05b57aa4ded578b709a704a38a" },
   "conform.nvim": { "branch": "master", "commit": "dca1a190aa85f9065979ef35802fb77131911106" },
   "copilot.lua": { "branch": "master", "commit": "61784cb7a1a109d72b9cb107ee70d11bc7d095ff" },
   "crates.nvim": { "branch": "main", "commit": "694357861ec9ebf12475ddcdd04ea45a0923c32d" },

--- a/.config/nvim/lazyvim.json
+++ b/.config/nvim/lazyvim.json
@@ -1,6 +1,5 @@
 {
   "extras": [
-    "lazyvim.plugins.extras.ai.codeium",
     "lazyvim.plugins.extras.ai.copilot",
     "lazyvim.plugins.extras.coding.yanky",
     "lazyvim.plugins.extras.editor.dial",


### PR DESCRIPTION
## Why

During a fresh bootstrap, the headless `nvim --headless "+Lazy! sync"` step **hung indefinitely** on:

```
Type number and <Enter> or click with the mouse (q or empty cancels):
please log in with :Codeium Auth
```

`codeium.nvim` prompts on `/dev/tty` during install (server download + auth), which **ignores the `</dev/null`** the bootstrap feeds it — so the prompt can't be dismissed and the run stalls. Codeium is also simply unused.

## What

- Remove `lazyvim.plugins.extras.ai.codeium` from `.config/nvim/lazyvim.json`.
- Remove the `codeium.nvim` entry from `lazy-lock.json`.

Both files re-validated as well-formed JSON; no remaining `codeium` references in the nvim config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)