### PR TITLE
Fix install-dotfiles.sh exiting 1 on a fresh machine (aborts bootstrap)

### DIFF
--- a/.korya.d/install-dotfiles.sh
+++ b/.korya.d/install-dotfiles.sh
@@ -78,4 +78,9 @@ git checkout -B "$BRANCH" "origin/$BRANCH" >/dev/null 2>&1
 git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
 
 ok "Dotfiles installed."
-[ "$n" -gt 0 ] && log "Your previous files are preserved in: $backup"
+# NB: keep this an `if`, not `[ … ] && log` — the latter exits 1 when n=0
+# (the normal fresh-machine case), which aborts the set -e bootstrap caller.
+if [ "$n" -gt 0 ]; then
+  log "Your previous files are preserved in: $backup"
+fi
+exit 0


### PR DESCRIPTION
## Symptom

On a genuinely fresh Mac, the bootstrap died silently right after the dotfiles step:

```
✓ Dotfiles installed.
dmitri@mercury ~ %        # back at the prompt — Homebrew/brew bundle never ran
```

…leaving a half-set-up machine (`.zprofile` wanting `/opt/homebrew/bin/brew`, `.zshrc` wanting `fzf`, neither installed).

## Root cause

`install-dotfiles.sh` ended with:

```sh
[ "$n" -gt 0 ] && log "Your previous files are preserved in: $backup"
```

When nothing was backed up (`n=0` — the normal case, since macOS doesn't pre-seed `.zshrc`/`.gitconfig`/etc.), the `[ … ]` test is false, so the **script's exit status is 1**. `bootstrap.sh` runs under `set -e`, so a non-zero from the dotfiles step **silently aborts the whole run**.

The earlier sandbox tests missed it because they always seeded a stock `.zshrc` (`n=1`, exit 0) — the one untested path (empty home) is the one real fresh machines hit.

## Fix

Replace the `&&` idiom with an `if` block + explicit `exit 0`.

## Testing

| Case | Exit |
|------|------|
| `n=0` (empty home) | 0 |
| `n>0` (stock `.zshrc`) | 0 |
| `set -e` caller (bootstrap-style) | continues past the dotfiles step |

🤖 Generated with [Claude Code](https://claude.com/claude-code)